### PR TITLE
Fix installation section to use phpenv and rbenv-aliases

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,10 +53,10 @@ $ phpenv install 7.2.6
 
 ## Installation
 
-    mkdir -p "$(rbenv root)/plugins"
-    git clone git://github.com/tpope/rbenv-aliases.git \
-      "$(rbenv root)/plugins/rbenv-aliases"
-    rbenv alias --auto
+    mkdir -p "$(phpenv root)/plugins"
+    git clone git://github.com/madumlao/phpenv-aliases.git \
+      "$(phpenv root)/plugins/phpenv-aliases"
+    phpenv alias --auto
 
 ## Thanks
 


### PR DESCRIPTION
Fix installation section to use phpenv and rbenv-aliases in README.markdown. Please confirm. Thank you.